### PR TITLE
Decorator should implement new translator contract for symfony >= 4.2

### DIFF
--- a/Translator/TranslatorDecorator.php
+++ b/Translator/TranslatorDecorator.php
@@ -5,12 +5,13 @@ namespace Sidus\BaseBundle\Translator;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Overrides base translator to ignore translations when domain is false
  */
-class TranslatorDecorator implements TranslatorInterface, TranslatorBagInterface
+class TranslatorDecorator implements LegacyTranslatorInterface, TranslatorInterface, TranslatorBagInterface
 {
     /** @var TranslatorInterface */
     protected $translator;

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "symfony/options-resolver": "~3.0|~4.0",
         "symfony/validator": "~3.0|~4.0",
         "symfony/translation": "~3.0|~4.0",
+        "symfony/translation-contracts": "^1.0",
         "symfony/var-dumper": "~3.0|~4.0"
     }
 }


### PR DESCRIPTION
In our sf4.4 project autowiring is failing 
- our services are requiring `\Symfony\Contracts\Translation\TranslatorInterface`
- the `\Sidus\BaseBundle\Translator\TranslatorDecorator` do not implement it, only the old interface

Solution : require & implement the contract (no BC break ?)

Note : I had to require `symfony/translation-contracts ^1.0`, not above, due to typed parameters in superior version => maybe this is something to watch for future symfony versions ?