### PR TITLE
Add missing interface

### DIFF
--- a/Translator/TranslatorDecorator.php
+++ b/Translator/TranslatorDecorator.php
@@ -5,12 +5,13 @@ namespace Sidus\BaseBundle\Translator;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Overrides base translator to ignore translations when domain is false
  */
-class TranslatorDecorator implements TranslatorInterface, TranslatorBagInterface
+class TranslatorDecorator implements TranslatorInterface, TranslatorBagInterface, LocaleAwareInterface
 {
     /** @var TranslatorInterface */
     protected $translator;
@@ -50,7 +51,7 @@ class TranslatorDecorator implements TranslatorInterface, TranslatorBagInterface
     /**
      * {@inheritdoc}
      */
-    public function setLocale($locale)
+    public function setLocale(string $locale)
     {
         $this->translator->setLocale($locale);
     }


### PR DESCRIPTION
Since Symfony 4.2 the Translator needs to implement the LocaleAwareInterface interface. We add this interface declaration and modify the signature of one of the functions to match what is declared in the interface